### PR TITLE
Fix for specs2 mutable specification bug

### DIFF
--- a/src/main/scala/specs2/Discipline.scala
+++ b/src/main/scala/specs2/Discipline.scala
@@ -8,7 +8,7 @@ import org.specs2.specification.Fragments
 import org.specs2.matcher.Parameters
 import org.specs2.matcher.ScalaCheckMatchers
 
-trait Discipline extends ScalaCheckMatchers { self: SpecificationLike =>
+trait Discipline extends ScalaCheckMatchers with SpecificationLike {
 
   def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit p: Parameters) = {
     val fragments =

--- a/src/test/scala/specs2/MutableDisciplineSpec.scala
+++ b/src/test/scala/specs2/MutableDisciplineSpec.scala
@@ -1,0 +1,8 @@
+package org.typelevel.discipline
+package specs2
+
+import org.specs2.mutable.Specification
+
+class MutableDisciplineSpec extends Specification with Discipline
+
+// vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
This pull request provides a potential fix to #3 by switching self-typing for extension in the definition of specs2 discipline.
