### PR TITLE
Dependency updates, Scala 2.12.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ jdk:
   - oraclejdk7
 matrix:
   include:
-  - scala: 2.12.0-M4
+  - scala: 2.12.0-M5
     jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Flexible law checking for Scala
 Usage
 -----
 
-This library is currently available for Scala binary versions 2.10 and 2.11.
+This library is currently available for Scala binary versions 2.10, 2.11 and 2.12.0-M5.
 
 To use the latest version, include the following in your `build.sbt`:
 
@@ -22,13 +22,13 @@ libraryDependencies +=
 Binding to test frameworks
 --------------------------
 
-Discipline is built against Scalacheck 1.12.x. There is also a published artifact for scala.js.
+Discipline is built against Scalacheck 1.13.x. There is also a published artifact for scala.js.
 
 There are bindings for Specs2 and ScalaTest. Since Discipline depends on them optionally, you have to add either one to your build explicitly:
 
 ```scala
 libraryDependencies +=
-  "org.scalatest" %% "scalatest" % "3.0.0-M7"
+  "org.scalatest" %% "scalatest" % "3.0.0"
   // or
-  "org.specs2" %% "specs2" % "3.6"
+  "org.specs2" %% "specs2" % "3.8.4"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 
 name := "discipline root project"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M5")
 
 lazy val commonSettings = releaseSettings ++ Seq(
   organization := "org.typelevel",
@@ -23,7 +23,7 @@ lazy val commonSettings = releaseSettings ++ Seq(
   ),
   libraryDependencies ++= Seq(
     "org.scalacheck" %%% "scalacheck" % "1.13.1",
-    "org.scalatest"  %%% "scalatest"  % "3.0.0-M16-SNAP4" % "optional"
+    "org.scalatest"  %%% "scalatest"  % "3.0.0" % "optional"
   ),
   resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
   scalacOptions in Test ++= Seq("-Yrangepos"),
@@ -94,17 +94,10 @@ lazy val root = project.in(file("."))
 lazy val discipline = crossProject.in(file("."))
   .settings(commonSettings: _*)
   .jvmSettings(
-    specs2Version := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor <= 11 =>
-          "3.7.3"
-        case _ =>
-          "3.7.3.1"
-      }
-    },
+    specs2Version := "3.8.4",
     libraryDependencies ++= Seq(  
       "org.specs2" %% "specs2-core"       % specs2Version.value % "optional",
-      "org.specs2" %% "specs2-scalacheck" % specs2Version.value % "optional" exclude("org.scalacheck", "scalacheck_2.12.0-M3")
+      "org.specs2" %% "specs2-scalacheck" % specs2Version.value % "optional" exclude("org.scalacheck", "scalacheck_2.12.0-M4")
     )
   )
   .jsSettings(scalaJSStage in Test := FastOptStage)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.sbt"  % "sbt-pgp"     % "0.8.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
-addSbtPlugin("org.scala-js"      % "sbt-scalajs" % "0.6.8")
+addSbtPlugin("org.scala-js"      % "sbt-scalajs" % "0.6.11")


### PR DESCRIPTION
Version updates:
 - scalatest -> 3.0.0
 - specs2 -> 3.8.4
 - sbt -> 0.3.12
 - Scala.js -> 0.6.11