### PR TITLE
use oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: scala
 scala:
   - 2.11.11
+  - 2.12.2
 jdk:
-  - oraclejdk7
-matrix:
-  include:
-  - scala: 2.12.2
-    jdk: oraclejdk8
+  - oraclejdk8


### PR DESCRIPTION
- travis-ci no longer support oraclejdk7 https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
- [sbt 1.x](https://github.com/typelevel/discipline/blob/5bd6407c9bcc088218955c7bd9b17f3b47e60a6c/project/build.properties) does not support java 7