### PR TITLE
use oraclejdk8 instead of oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,10 @@ language: scala
 scala:
   - 2.10.7
   - 2.11.12
+  - 2.12.6
+  - 2.13.0-M3
 jdk:
-  - oraclejdk7
-matrix:
-  include:
-  - scala: 2.12.6
-    jdk: oraclejdk8
-  - scala: 2.13.0-M3
-    jdk: oraclejdk8
+  - oraclejdk8
 script:
   - sbt "++ ${TRAVIS_SCALA_VERSION}!" test
 


### PR DESCRIPTION
- travis-ci no longer support oraclejdk7 https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
- sbt 1.x does not support jdk7