### PR TITLE
Ruleset checks were made to be tabbed according to specs2 custom

### DIFF
--- a/shared/src/main/scala/specs2/Discipline.scala
+++ b/shared/src/main/scala/specs2/Discipline.scala
@@ -11,10 +11,10 @@ import org.specs2.scalacheck.Parameters
 trait Discipline extends ScalaCheck { self: SpecificationLike =>
 
   def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit p: Parameters) = {
-    s"""${ruleSet.name} laws must hold for ${name}""" ^ br ^
+    s"""${ruleSet.name} laws must hold for ${name}""" ^ br ^ t ^
     Fragments.foreach(ruleSet.all.properties.toList) { case (id, prop) =>
        id ! check(prop, p, defaultFreqMapPretty) ^ br
-    }
+    } ^ br ^ bt
   }
 
 }


### PR DESCRIPTION
Various sublists in specs2 are usually tabbed. This PR makes such tabbing for `RuleSet`s that are checked with `checkAll` function.