### PR TITLE
Add the Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ libraryDependencies +=
   // or
   "org.specs2" %% "specs2-scalacheck" % "4.3.0"
 ```
+
+Code of Conduct
+---------------
+
+See the [Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Typelevel has [standardized on the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html).  This makes it explicit for discipline.