### PR TITLE
Proposal: name new core module the core module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,10 @@ lazy val discipline = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("core"))
   .settings(commonSettings: _*)
-  .settings(libraryDependencies += "org.specs2" %%% "specs2-scalacheck" % specs2Version % Test)
+  .settings(
+    moduleName := "discipline-core",
+    libraryDependencies += "org.specs2" %%% "specs2-scalacheck" % specs2Version % Test
+  )
   .jsSettings(scalaJSStage in Test := FastOptStage)
 
 lazy val disciplineJVM = discipline.jvm


### PR DESCRIPTION
Once #95 is updated and merged we should publish an 0.12.0 release to unblock Cats, etc. (and then maybe eventually once 2.13.0 is out and we have a stable ScalaTest release we could do a 1.0.0).

Since the next release will split the discipline artifact into modules, I thought it might make sense to rename the core module `discipline-core`, so that instead of this (the current configuration):

```
"org.typelevel" %%% "discipline" % ...
"org.typelevel" %%% "discipline-scalatest" % ...
"org.typelevel" %%% "discipline-specs2" % ...
```
We have this:
```
"org.typelevel" %%% "discipline-core" % ...
"org.typelevel" %%% "discipline-scalatest" % ...
"org.typelevel" %%% "discipline-specs2" % ...
```
This follows the idiom of Cats, circe, and many other projects, and more clearly flags to users that the module structure has changed.

What do people think?

r? @larsrh 